### PR TITLE
FacebookLikeView crashes on iOS 3

### DIFF
--- a/FacebookLikeView/Classes/FacebookLikeView.m
+++ b/FacebookLikeView/Classes/FacebookLikeView.m
@@ -139,7 +139,7 @@
     }
     
     // Block redirects to the Facebook login page and notify the delegate that we've done so
-    else if ([request.URL.lastPathComponent isEqualToString:@"login.php"]) {
+    else if ([request.URL.path.lastPathComponent isEqualToString:@"login.php"]) {
         [_delegate facebookLikeViewRequiresLogin:self];
         return NO;
     }


### PR DESCRIPTION
Apple docs claim that `-[NSURL lastPathComponent]` is available for iOS 2, but it is not true. Therefore use `-[NSString lastPathComponent]` instead.
